### PR TITLE
Heroku listen error fix

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@
  */
 
 const html_entities = require('he');
+const http = require('http');
 const twitter = require('twitter');
 const cp = require('child_process');
 
@@ -193,6 +194,8 @@ if (process.env.TWTR_USER_ID
   });
 
   setInterval(main, 60*1000, client);
+
+  http.createServer().listen(process.env.PORT || 8103);
 
 } else {
   console.error('Error: Missing environment variables');


### PR DESCRIPTION
```
Apr 11 20:55:22 bf-interpreter heroku/web.1:  Starting process with command `npm start` 
Apr 11 20:55:24 bf-interpreter app/web.1:  > bf-interpreter@0.1.0 start /app 
Apr 11 20:55:24 bf-interpreter app/web.1:  > node server.js 
Apr 11 20:56:22 bf-interpreter heroku/web.1:  Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch 
Apr 11 20:56:22 bf-interpreter heroku/web.1:  Stopping process with SIGKILL 
Apr 11 20:56:22 bf-interpreter heroku/web.1:  State changed from starting to crashed 
Apr 11 20:56:22 bf-interpreter heroku/web.1:  Process exited with status 137 
```